### PR TITLE
Update to Bynder Field

### DIFF
--- a/v1/src/app/globals.css
+++ b/v1/src/app/globals.css
@@ -18,10 +18,4 @@
 
 body {
   color: rgb(var(--foreground-rgb));
-  background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb));
 }

--- a/v1/src/app/layout.tsx
+++ b/v1/src/app/layout.tsx
@@ -1,19 +1,25 @@
-import './globals.css'
-import "@agility/plenum-ui/lib/tailwind.css"
-import classNames from 'classnames'
-import {Mulish} from "next/font/google"
+import "./globals.css";
+import "@agility/plenum-ui/lib/tailwind.css";
+import classNames from "classnames";
+import { Mulish } from "next/font/google";
 
-const mulish = Mulish({subsets: ["latin"]})
+const mulish = Mulish({ subsets: ["latin"] });
 
 export const metadata = {
-	title: "Agility CMS Bynder App",
-	description: "Connect your Bynder assets with Agility",
-}
+  title: "Agility CMS Bynder App",
+  description: "Connect your Bynder assets with Agility",
+};
 
-export default function RootLayout({children}: {children: React.ReactNode}) {
-	return (
-		<html lang="en" className="h-full bg-white">
-			<body className={classNames(mulish.className, "bg-white h-full text-black")}>{children}</body>
-		</html>
-	)
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" className="h-full">
+      <body className={classNames(mulish.className, "h-full text-black")}>
+        {children}
+      </body>
+    </html>
+  );
 }

--- a/v1/src/components/AssetSelector.tsx
+++ b/v1/src/components/AssetSelector.tsx
@@ -1,7 +1,7 @@
-"use client"
-import {useAgilityAppSDK, closeModal} from "@agility/app-sdk"
-import {CompactView, Login, assetType} from "@bynder/compact-view"
-import {useMemo} from "react"
+"use client";
+import { useAgilityAppSDK, closeModal } from "@agility/app-sdk";
+import { CompactView, Login, assetType } from "@bynder/compact-view";
+import { useMemo } from "react";
 
 const assetFieldSelection = `
   name
@@ -14,49 +14,49 @@ const assetFieldSelection = `
   ... on Video {
     previewUrls
   }
-`
+`;
 
 export default function BynderAssetSelector() {
-	const {initializing, appInstallContext, modalProps} = useAgilityAppSDK()
+  const { initializing, appInstallContext, modalProps } = useAgilityAppSDK();
 
-	const config = appInstallContext?.configuration
+  const config = appInstallContext?.configuration;
 
-	const bynderUrl = useMemo(() => {
-		return config?.bynderurl
-	}, [config])
+  const bynderUrl = useMemo(() => {
+    return config?.bynderurl;
+  }, [config]);
 
-	if (initializing) {
-		return null
-	}
+  if (initializing) {
+    return null;
+  }
 
-	if (!bynderUrl) {
-		return <div>Please ensure this app has been properly configured.</div>
-	}
+  if (!bynderUrl) {
+    return <div>Please ensure this app has been properly configured.</div>;
+  }
 
-	const assetType = modalProps?.assetType || "IMAGE"
+  const assetType = modalProps?.assetType || "IMAGE";
 
-	return (
-		<div id="media-container" className="flex flex-col h-full min-h-0">
-			<div className="relative flex-1 overflow-hidden">
-				<Login
-					portal={{
-						url: bynderUrl,
-						editable: false,
-					}}
-				>
-					<CompactView
-						mode="SingleSelect"
-						language="en_US"
-						assetTypes={assetType && [assetType]}
-						isContainerMode
-						onSuccess={(assets) => {
-							const [asset] = assets
-							closeModal(asset)
-						}}
-						assetFieldSelection={assetFieldSelection}
-					/>
-				</Login>
-			</div>
-		</div>
-	)
+  return (
+    <div id="media-container" className="flex flex-col h-full min-h-0">
+      <div className="relative flex-1 overflow-hidden">
+        <Login
+          portal={{
+            url: bynderUrl,
+            editable: false,
+          }}
+        >
+          <CompactView
+            mode="SingleSelectFile"
+            language="en_US"
+            assetTypes={assetType && [assetType]}
+            isContainerMode
+            onSuccess={(assets) => {
+              const [asset] = assets;
+              closeModal(asset);
+            }}
+            assetFieldSelection={assetFieldSelection}
+          />
+        </Login>
+      </div>
+    </div>
+  );
 }

--- a/v1/src/components/BynderImageField.tsx
+++ b/v1/src/components/BynderImageField.tsx
@@ -1,99 +1,124 @@
-import {contentItemMethods, openModal, useAgilityAppSDK, useResizeHeight} from "@agility/app-sdk"
-import {useMemo} from "react"
-import EmptySection from "./EmptySection"
-import AttachmentOverlay from "./AttachmentOverlay"
-import Metadata from "./Metadata"
-import {IconBuildingStore, IconPhoto, IconPhotoOff} from "@tabler/icons-react"
-import {Button} from "@agility/plenum-ui"
-import FieldHeader from "./FieldHeader"
+import {
+  contentItemMethods,
+  openModal,
+  useAgilityAppSDK,
+  useResizeHeight,
+} from "@agility/app-sdk";
+import { useMemo } from "react";
+import EmptySection from "./EmptySection";
+import AttachmentOverlay from "./AttachmentOverlay";
+import Metadata from "./Metadata";
+import {
+  IconBuildingStore,
+  IconPhoto,
+  IconPhotoOff,
+} from "@tabler/icons-react";
+import { Button } from "@agility/plenum-ui";
+import FieldHeader from "./FieldHeader";
 
 export default function BynderImageField() {
-	const {initializing, appInstallContext, field, fieldValue} = useAgilityAppSDK()
+  const { initializing, appInstallContext, field, fieldValue } =
+    useAgilityAppSDK();
 
-	const ref = useResizeHeight()
+  const ref = useResizeHeight();
 
-	const attachment = useMemo(() => {
-		try {
-			return JSON.parse(fieldValue)
-		} catch (e) {
-			return null
-		}
-	}, [fieldValue])
+  const attachment = useMemo(() => {
+    try {
+      return JSON.parse(fieldValue);
+    } catch (e) {
+      return null;
+    }
+  }, [fieldValue]);
 
-	const setAltText = (alt: string) => {
-		if (!attachment) return
-		attachment.alt = alt
+  const setAltText = (alt: string) => {
+    if (!attachment) return;
+    attachment.alt = alt;
 
-		const assetStr = JSON.stringify(attachment)
-		contentItemMethods.setFieldValue({value: assetStr})
+    const assetStr = JSON.stringify(attachment);
+    contentItemMethods.setFieldValue({ value: assetStr });
+  };
+  //TODO: add readonly props....
+  const selectImage = () => {
+    openModal<any | null>({
+      title: "Select an Image",
+      name: "bynder-asset-selector",
+      props: {
+        assetType: "IMAGE",
+      },
+      callback: (result: any | null | undefined) => {
+        if (!result) {
+          return;
+        }
+        const assetStr = JSON.stringify(result);
+        contentItemMethods.setFieldValue({ value: assetStr });
+      },
+    });
+  };
 
-	}
-	//TODO: add readonly props....
-	const selectImage = () => {
-		openModal<any | null>({
-			title: "Select an Image",
-			name: "bynder-asset-selector",
-			props: {
-				assetType: "IMAGE",
-			},
-			callback: (result: any | null | undefined) => {
-				if (!result) {
-					return
-				}
-				const assetStr = JSON.stringify(result)
-				contentItemMethods.setFieldValue({value: assetStr})
-			},
-		})
-	}
+  if (initializing) return <div></div>;
 
-	if (initializing) return <div></div>
-
-	return (
-		<div ref={ref}>
-			{attachment && (
-				<>
-					<FieldHeader
-						fieldConfig={{readOnly: false}}
-						attachment={attachment}
-						handleRemove={() => {
-							contentItemMethods.setFieldValue({value: ""})
-						}}
-						handleSelect={() => selectImage()}
-					/>
-					<div className="mt-2 flex w-full flex-row flex-wrap rounded border border-gray-300">
-						<div
-							className={`relative flex h-[270px] xs:w-full sm:w-[275px]`}
-							style={{
-								background: "repeating-conic-gradient(#D9D9D9 0% 25%, transparent 0% 50%) 50% / 20px 20px",
-							}}
-						>
-							<div
-								className={
-									"mx-auto flex h-full w-full max-w-[275px] items-center justify-center border-0 bg-contain bg-clip-border bg-center bg-no-repeat"
-								}
-								style={{
-									backgroundImage: `url(${attachment?.derivatives?.thumbnail || attachment?.url})`,
-								}}
-							></div>
-							<AttachmentOverlay isImage={true} />
-							<i className="fa fa-picture-o" aria-hidden="true"></i>
-						</div>
-						<Metadata attachment={attachment} isReadonly={false} handleAltTextChange={setAltText} isImage={true} />
-					</div>
-				</>
-			)}
-			{!attachment && (
-				<div>
-					<EmptySection
-						{...{
-							messageHeading: "No Image Attached",
-							messageBody: "Click to select an image.",
-							icon: <IconPhotoOff className="text-gray-400 h-12 w-12" stroke={1} />,
-							buttonComponent: <Button type="alternative" onClick={() => selectImage()} label="Browse" />,
-						}}
-					/>
-				</div>
-			)}
-		</div>
-	)
+  return (
+    <div ref={ref}>
+      {attachment && (
+        <>
+          <FieldHeader
+            fieldConfig={{ readOnly: false }}
+            attachment={attachment}
+            handleRemove={() => {
+              contentItemMethods.setFieldValue({ value: "" });
+            }}
+            handleSelect={() => selectImage()}
+          />
+          <div className="mt-2 flex w-full flex-row flex-wrap rounded border border-gray-300 bg-white">
+            <div
+              className={`relative flex h-[270px] xs:w-full sm:w-[275px]`}
+              style={{
+                background:
+                  "repeating-conic-gradient(#D9D9D9 0% 25%, transparent 0% 50%) 50% / 20px 20px",
+              }}
+            >
+              <div
+                className={
+                  "mx-auto flex h-full w-full max-w-[275px] items-center justify-center border-0 bg-contain bg-clip-border bg-center bg-no-repeat"
+                }
+                style={{
+                  backgroundImage: `url(${
+                    attachment?.derivatives?.thumbnail || attachment?.url
+                  })`,
+                }}
+              ></div>
+              <AttachmentOverlay isImage={true} />
+              <i className="fa fa-picture-o" aria-hidden="true"></i>
+            </div>
+            <Metadata
+              attachment={attachment}
+              isReadonly={false}
+              handleAltTextChange={setAltText}
+              isImage={true}
+            />
+          </div>
+        </>
+      )}
+      {!attachment && (
+        <div>
+          <EmptySection
+            {...{
+              messageHeading: "No Image Attached",
+              messageBody: "Click to select an image.",
+              icon: (
+                <IconPhotoOff className="text-gray-400 h-12 w-12" stroke={1} />
+              ),
+              buttonComponent: (
+                <Button
+                  type="alternative"
+                  onClick={() => selectImage()}
+                  label="Browse"
+                />
+              ),
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
 }

--- a/v1/src/components/BynderVideoField.tsx
+++ b/v1/src/components/BynderVideoField.tsx
@@ -1,94 +1,119 @@
-import {contentItemMethods, openModal, useAgilityAppSDK, useResizeHeight} from "@agility/app-sdk"
-import {useMemo} from "react"
-import EmptySection from "./EmptySection"
-import AttachmentOverlay from "./AttachmentOverlay"
-import Metadata from "./Metadata"
-import {IconBuildingStore, IconPhoto, IconPhotoOff, IconVideoOff} from "@tabler/icons-react"
-import {Button} from "@agility/plenum-ui"
-import FieldHeader from "./FieldHeader"
+import {
+  contentItemMethods,
+  openModal,
+  useAgilityAppSDK,
+  useResizeHeight,
+} from "@agility/app-sdk";
+import { useMemo } from "react";
+import EmptySection from "./EmptySection";
+import AttachmentOverlay from "./AttachmentOverlay";
+import Metadata from "./Metadata";
+import {
+  IconBuildingStore,
+  IconPhoto,
+  IconPhotoOff,
+  IconVideoOff,
+} from "@tabler/icons-react";
+import { Button } from "@agility/plenum-ui";
+import FieldHeader from "./FieldHeader";
 
 export default function BynderVideoField() {
-	const {initializing, appInstallContext, field, fieldValue} = useAgilityAppSDK()
+  const { initializing, appInstallContext, field, fieldValue } =
+    useAgilityAppSDK();
 
-	const ref = useResizeHeight()
+  const ref = useResizeHeight();
 
-	const attachment = useMemo(() => {
-		try {
-			return JSON.parse(fieldValue)
-		} catch (e) {
-			return null
-		}
-	}, [fieldValue])
+  const attachment = useMemo(() => {
+    try {
+      return JSON.parse(fieldValue);
+    } catch (e) {
+      return null;
+    }
+  }, [fieldValue]);
 
-	const setAltText = (alt: string) => {
-		//do nothing
-	}
-	//TODO: add readonly props....
-	const selectImage = () => {
-		openModal<any | null>({
-			title: "Select a Video",
-			name: "bynder-asset-selector",
-			props: {
-				assetType: "VIDEO",
-			},
-			callback: (result: any | null | undefined) => {
-				if (!result) {
-					return
-				}
+  const setAltText = (alt: string) => {
+    //do nothing
+  };
+  //TODO: add readonly props....
+  const selectImage = () => {
+    openModal<any | null>({
+      title: "Select a Video",
+      name: "bynder-asset-selector",
+      props: {
+        assetType: "VIDEO",
+      },
+      callback: (result: any | null | undefined) => {
+        if (!result) {
+          return;
+        }
 
-				const assetStr = JSON.stringify(result)
-				contentItemMethods.setFieldValue({value: assetStr})
-			},
-		})
-	}
+        const assetStr = JSON.stringify(result);
+        contentItemMethods.setFieldValue({ value: assetStr });
+      },
+    });
+  };
 
-	if (initializing) return <div></div>
+  if (initializing) return <div></div>;
 
-	return (
-		<div ref={ref}>
-			{attachment && (
-				<>
-					<FieldHeader
-						fieldConfig={{readOnly: false}}
-						attachment={attachment}
-						handleRemove={() => {
-							contentItemMethods.setFieldValue({value: ""})
-						}}
-						handleSelect={() => selectImage()}
-					/>
-					<div className="mt-2 flex w-full flex-row flex-wrap rounded border border-gray-300">
-						<div
-							className={`relative flex h-[270px] xs:w-full sm:w-[275px]`}
-							style={{
-								background: "repeating-conic-gradient(#D9D9D9 0% 25%, transparent 0% 50%) 50% / 20px 20px",
-							}}
-						>
-							<video
-								controls
-								poster={attachment?.files?.thumbnail?.url}
-								className="border-[3px] transition-all border-gray-300  focus-within:border-purple-600 hover:border-purple-600 w-full"
-							>
-								<source src={attachment?.previewUrls[0]} type="video/mp4" />
-							</video>
-							<AttachmentOverlay isImage={false} />
-							<i className="fa fa-picture-o" aria-hidden="true"></i>
-						</div>
-						<Metadata attachment={attachment} isReadonly={false} handleAltTextChange={setAltText} isImage={false} />
-					</div>
-				</>
-			)}
-			{!attachment && (
-				<div>
-					<EmptySection
-						{...{
-							messageHeading: "No Video Attached",
-							messageBody: "Click to select a video.",
-							icon: <IconVideoOff className="text-gray-400 h-12 w-12" stroke={1} />,
-							buttonComponent: <Button type="alternative" onClick={() => selectImage()} label="Browse" />,
-						}}
-					/>
-				</div>
-			)}
-		</div>
-	)
+  return (
+    <div ref={ref}>
+      {attachment && (
+        <>
+          <FieldHeader
+            fieldConfig={{ readOnly: false }}
+            attachment={attachment}
+            handleRemove={() => {
+              contentItemMethods.setFieldValue({ value: "" });
+            }}
+            handleSelect={() => selectImage()}
+          />
+          <div className="mt-2 flex w-full flex-row flex-wrap rounded border border-gray-300 bg-white">
+            <div
+              className={`relative flex h-[270px] xs:w-full sm:w-[275px]`}
+              style={{
+                background:
+                  "repeating-conic-gradient(#D9D9D9 0% 25%, transparent 0% 50%) 50% / 20px 20px",
+              }}
+            >
+              <video
+                controls
+                poster={attachment?.files?.thumbnail?.url}
+                className="border-[3px] transition-all border-gray-300  focus-within:border-purple-600 hover:border-purple-600 w-full"
+              >
+                <source src={attachment?.previewUrls[0]} type="video/mp4" />
+              </video>
+              <AttachmentOverlay isImage={false} />
+              <i className="fa fa-picture-o" aria-hidden="true"></i>
+            </div>
+            <Metadata
+              attachment={attachment}
+              isReadonly={false}
+              handleAltTextChange={setAltText}
+              isImage={false}
+            />
+          </div>
+        </>
+      )}
+      {!attachment && (
+        <div>
+          <EmptySection
+            {...{
+              messageHeading: "No Video Attached",
+              messageBody: "Click to select a video.",
+              icon: (
+                <IconVideoOff className="text-gray-400 h-12 w-12" stroke={1} />
+              ),
+              buttonComponent: (
+                <Button
+                  type="alternative"
+                  onClick={() => selectImage()}
+                  label="Browse"
+                />
+              ),
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
 }

--- a/v1/src/components/FieldHeader.tsx
+++ b/v1/src/components/FieldHeader.tsx
@@ -1,60 +1,68 @@
-import React from "react"
-import {Button, ButtonDropDown} from "@agility/plenum-ui"
-import { IconChevronDown } from "@tabler/icons-react"
+import React from "react";
+import { Button, ButtonDropDown } from "@agility/plenum-ui";
+import { IconChevronDown } from "@tabler/icons-react";
 
 interface Props {
-	fieldConfig: {
-		readOnly: boolean
-	}
-	attachment: any
-	handleRemove: () => void
-	handleSelect: () => void
+  fieldConfig: {
+    readOnly: boolean;
+  };
+  attachment: any;
+  handleRemove: () => void;
+  handleSelect: () => void;
 }
 
-const FieldHeader = ({fieldConfig, attachment, handleRemove, handleSelect}: Props) => {
-	return (
-		<div className="flex w-full items-center justify-between pb-1 font-muli">
-			<div className="flex items-center" />
-			{fieldConfig.readOnly !== true && (
-				<div className="top-buttons">
-					{attachment ? (
-						<ButtonDropDown
-							button={{
-								icon: "CollectionIcon",
-								label: "Browse",
-								size: "sm",
-								onClick: () => handleSelect(),
-								type: "secondary",
-							}}
-							dropDown={{
-								IconElement: () => (
-									<IconChevronDown className="h-5 w-5 text-purple-600" stroke={2} />
-								),
-								items: [
-									[
-										{
-											icon: "TrashIcon",
-											label: "Remove",
-											isEmphasized: true,
-											onClick: () => handleRemove(),
-										},
-									],
-								],
-							}}
-						/>
-					) : (
-						<Button
-							icon="FolderDownloadIcon"
-							label="Browse"
-							size="sm"
-							onClick={() => handleSelect()}
-							type="secondary"
-						/>
-					)}
-				</div>
-			)}
-		</div>
-	)
-}
+const FieldHeader = ({
+  fieldConfig,
+  attachment,
+  handleRemove,
+  handleSelect,
+}: Props) => {
+  return (
+    <div className="flex w-full items-center justify-between pb-1 font-muli">
+      <div className="flex items-center" />
+      {fieldConfig.readOnly !== true && (
+        <div className="top-buttons">
+          {attachment ? (
+            <ButtonDropDown
+              button={{
+                icon: "ViewGridIcon",
+                label: "Browse",
+                size: "sm",
+                onClick: () => handleSelect(),
+                type: "alternative",
+              }}
+              dropDown={{
+                IconElement: () => (
+                  <IconChevronDown
+                    className="h-5 w-5 text-purple-600"
+                    stroke={2}
+                  />
+                ),
+                items: [
+                  [
+                    {
+                      icon: "TrashIcon",
+                      label: "Remove",
+                      isEmphasized: true,
+                      onClick: () => handleRemove(),
+                    },
+                  ],
+                ],
+              }}
+            />
+          ) : (
+            <Button
+              icon="FolderDownloadIcon"
+              label="Browse"
+              size="sm"
+              onClick={() => handleSelect()}
+              type="secondary"
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
 
-export default FieldHeader
+export default FieldHeader;

--- a/v1/src/components/Metadata.tsx
+++ b/v1/src/components/Metadata.tsx
@@ -1,62 +1,63 @@
-
 import fileSizeFromBytes from "../utils/fileSizeFromBytes";
 import { TextInput } from "@agility/plenum-ui";
 import { MetaRow } from "./MetaRow";
 
 interface Props {
-	attachment: any
-	isReadonly: boolean
-	handleAltTextChange: any
-	isImage: any
+  attachment: any;
+  isReadonly: boolean;
+  handleAltTextChange: any;
+  isImage: any;
 }
 
-const Metadata = ({ attachment, isReadonly, handleAltTextChange, isImage }: Props) => {
+const Metadata = ({
+  attachment,
+  isReadonly,
+  handleAltTextChange,
+  isImage,
+}: Props) => {
+  const orig =
+    attachment && attachment.files ? attachment.files.original : null;
 
-	const orig = attachment && attachment.files ? attachment.files.original : null
+  let fileName = attachment.originalUrl || "";
+  if (fileName.includes("/")) {
+    fileName = fileName.substring(fileName.lastIndexOf("/") + 1);
+  }
 
-	let fileName = attachment.originalUrl || ""
-	if (fileName.includes("/")) {
-		fileName = fileName.substring(fileName.lastIndexOf("/") + 1)
-	}
+  return (
+    <div className="mx-6 w-full flex-1 font-muli bg-white min-w-[275px]">
+      {isImage && (
+        <TextInput
+          type="text"
+          label="Alt Text"
+          placeholder="Enter alt text"
+          className="form-control agility-attachment-alt"
+          value={attachment?.alt || attachment?.name || ""}
+          onChange={(val) => handleAltTextChange(val)}
+          isReadonly={isReadonly}
+        />
+      )}
 
-	console.log("orig", orig)
-
-
-	return (
-		<div className="mx-6 w-full flex-1 font-muli bg-white min-w-[275px]">
-			{isImage && (
-				<TextInput
-					type="text"
-					label="Alt Text"
-					placeholder="Enter alt text"
-					className="form-control agility-attachment-alt"
-					value={attachment?.alt || attachment?.name || ""}
-					onChange={(val) => handleAltTextChange(val)}
-					isReadonly={isReadonly}
-				/>
-			)}
-
-			<MetaRow label={"Size"} value={fileSizeFromBytes(orig?.fileSize)} />
-			<>
-				{orig?.width > 0 && <MetaRow label={"Width"} value={orig?.width} />}
-				{orig?.height > 0 && <MetaRow label={"Height"} value={orig?.height} />}
-			</>
-			<MetaRow
-				label={"URL"}
-				className={"border-b-0 border-b-transparent"}
-				value={
-					<a
-						className="block break-all text-purple-600 line-clamp-1 hover:underline"
-						href={attachment.originalUrl}
-						target="_blank"
-						rel="noreferrer"
-					>
-						{fileName || "Asset URL"}
-					</a>
-				}
-			/>
-		</div>
-	)
-}
+      <MetaRow label={"Size"} value={fileSizeFromBytes(orig?.fileSize)} />
+      <>
+        {orig?.width > 0 && <MetaRow label={"Width"} value={orig?.width} />}
+        {orig?.height > 0 && <MetaRow label={"Height"} value={orig?.height} />}
+      </>
+      <MetaRow
+        label={"URL"}
+        className={"border-b-0 border-b-transparent"}
+        value={
+          <a
+            className="block break-all text-purple-600 line-clamp-1 hover:underline"
+            href={attachment.originalUrl}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {fileName || "Asset URL"}
+          </a>
+        }
+      />
+    </div>
+  );
+};
 
 export default Metadata;


### PR DESCRIPTION
Closes https://github.com/agility/agility-cms-app-bynder/issues/2

Updates in this PR
1. Made the bynder field look more similar to our image field
2. Changed the `mode` for Bynder from `SingleSelect` to `SingleSelectFile`. This enables the variant dropdown to be shown on the bottom right of the modal
<img width="1073" height="138" alt="image" src="https://github.com/user-attachments/assets/05b55dd3-1f31-4459-b5b0-531b19cef280" />

The difference b etween `SingleSelect` and `SingleSelectFile`

```
SingleSelect: Users can only select a single asset. In this case, onSuccess callback will receive an array with a single element containing the selected asset.
SingleSelectFile: In addition to SingleSelect behaviour, users will be prompted to select an asset derivative. This derivative can be a built-in derivative, a custom derivative (if available publicly) or the original file (if available publicly). Selected file information will be then passed in an object as the second argument of onSuccess callback under selectedFile key.
```

### To test
1. Go to this instance that has the bynder app set up https://app-qa.publishwithagility.com/instance/88cc7aee-d/en-us/content/list-70/listitem-146
2. Click on the Bynder Image field and click browse
3. Select the file called `derivative_test_headshot` and aftert selection, notice that there is a dropdown for selecting derivates at the bottom right of the modal