### PR TITLE
Save the selected file and not the whole asset

### DIFF
--- a/v1/src/components/AssetSelector.tsx
+++ b/v1/src/components/AssetSelector.tsx
@@ -49,9 +49,8 @@ export default function BynderAssetSelector() {
             language="en_US"
             assetTypes={assetType && [assetType]}
             isContainerMode
-            onSuccess={(assets) => {
-              const [asset] = assets;
-              closeModal(asset);
+            onSuccess={(_, selectedFile) => {
+              closeModal(selectedFile.selectedFile);
             }}
             assetFieldSelection={assetFieldSelection}
           />


### PR DESCRIPTION
Closes https://agilitycms.atlassian.net/browse/PROD-711

Oxford is reporting that when we use Bynder, we are saving the whole asset with all the derivates. The fix here will change it so that it only saves the selected variation.